### PR TITLE
fix error message in case DJANGO_VITE_STATIC_URL_PREFIX is set wrong

### DIFF
--- a/django_vite/templatetags/django_vite.py
+++ b/django_vite/templatetags/django_vite.py
@@ -107,7 +107,7 @@ class DjangoViteAssetLoader:
                 {"type": "module", "async": "", "defer": ""},
             )
 
-        if path not in self._manifest:
+        if not self._manifest or path not in self._manifest:
             raise RuntimeError(
                 f"Cannot find {path} in Vite manifest "
                 f"at {DJANGO_VITE_MANIFEST_PATH}"
@@ -184,7 +184,7 @@ class DjangoViteAssetLoader:
         if DJANGO_VITE_DEV_MODE:
             return DjangoViteAssetLoader._generate_vite_server_url(path)
 
-        if path not in self._manifest:
+        if not self._manifest or path not in self._manifest:
             raise RuntimeError(
                 f"Cannot find {path} in Vite manifest "
                 f"at {DJANGO_VITE_MANIFEST_PATH}"
@@ -252,7 +252,7 @@ class DjangoViteAssetLoader:
         if DJANGO_VITE_DEV_MODE:
             return ""
 
-        if path not in self._manifest:
+        if not self._manifest or path not in self._manifest:
             raise RuntimeError(
                 f"Cannot find {path} in Vite manifest "
                 f"at {DJANGO_VITE_MANIFEST_PATH}"


### PR DESCRIPTION
In case the `DJANGO_VITE_STATIC_URL_PREFIX` variable is set to wrong value, `django-vite` will throw this confusing error message:
```
  File "/usr/local/lib/python3.9/site-packages/django/template/library.py", line 192, in render
    output = self.func(*resolved_args, **resolved_kwargs)
  File "/usr/local/lib/python3.9/site-packages/django/utils/safestring.py", line 46, in wrapped
    return safety_marker(func(*args, **kwargs))
  File "/usr/local/lib/python3.9/site-packages/django_vite/templatetags/django_vite.py", line 425, in vite_asset
    return DjangoViteAssetLoader.instance().generate_vite_asset(
  File "/usr/local/lib/python3.9/site-packages/django_vite/templatetags/django_vite.py", line 110, in generate_vite_asset
    if path not in self._manifest:
TypeError: argument of type 'NoneType' is not iterable
```

With this patch, it will throw the original `Cannot find {path} in Vite manifest...` RuntimeError