### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ You can redefine those variables in your `settings.py` :
   setting of Django.
 
 - If you are serving your static files with whitenoise, by default your files compiled by vite will not be considered immutable and a bad cache-control will be set. To fix this you will need to set a custom test like so:
-```
+```python
 import re
 # Vite generates files with 8 hash digits
 # http://whitenoise.evans.io/en/stable/django.html#WHITENOISE_IMMUTABLE_FILE_TEST


### PR DESCRIPTION
Hi there,

I saw an issue with your ~linting~ highlighting  in `README.md`. The code block should specify python for proper linting. This pull request essentially fixes that :)

### Before : 
![2](https://user-images.githubusercontent.com/61817579/156920278-82b54490-71db-4bf4-9d92-6dc1eb894236.PNG)

### After :
![1](https://user-images.githubusercontent.com/61817579/156920275-98fe3bd8-fa3c-4e40-bcae-0cfc60af85f8.PNG)



