### PR TITLE
Add template tag to enable react-refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ This will generate only the URL to an asset with no tag surrounding it.
 **Warning, this does not generate URLs for dependant assets of this one
 like the previous tag.**
 
+```
+{% vite_react_refresh %}
+```
+If you're using React, this will generate the Javascript needed to support React HMR. 
+
 ### Custom attributes
 
 By default, all scripts tags are generated with a `type="module"` and `crossorigin=""` attributes just like ViteJS do by default if you are building a single-page app.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ like the previous tag.**
 ```
 {% vite_react_refresh %}
 ```
-If you're using React, this will generate the Javascript needed to support React HMR. 
+If you're using React, this will generate the Javascript needed to support React HMR.
 
 ### Custom attributes
 

--- a/django_vite/templatetags/django_vite.py
+++ b/django_vite/templatetags/django_vite.py
@@ -33,6 +33,10 @@ DJANGO_VITE_WS_CLIENT_URL = getattr(
     settings, "DJANGO_VITE_WS_CLIENT_URL", "@vite/client"
 )
 
+DJANGO_VITE_REACT_REFRESH_URL = getattr(
+    settings, "DJANGO_VITE_REACT_REFRESH_URL", "@react-refresh"
+)
+
 # Location of Vite compiled assets (only used in Vite production mode).
 # Must be included in your "STATICFILES_DIRS".
 # In Django production mode this folder need to be collected as static
@@ -400,6 +404,19 @@ class DjangoViteAssetLoader:
             f"{DJANGO_VITE_DEV_SERVER_HOST}:{DJANGO_VITE_DEV_SERVER_PORT}",
             urljoin(DJANGO_VITE_STATIC_URL, path),
         )
+    
+    @classmethod
+    def generate_vite_react_refresh_url(cls) -> str:
+        if not DJANGO_VITE_DEV_MODE:
+            return ""
+
+        return f"""<script type="module">
+            import RefreshRuntime from '{cls._generate_vite_server_url(DJANGO_VITE_REACT_REFRESH_URL)}'
+            RefreshRuntime.injectIntoGlobalHook(window)
+            window.$RefreshReg$ = () => {{}}
+            window.$RefreshSig$ = () => (type) => type
+            window.__vite_plugin_react_preamble_installed__ = true
+        </script>"""
 
 
 # Make Loader instance at startup to prevent threading problems
@@ -537,3 +554,8 @@ def vite_legacy_asset(
     return DjangoViteAssetLoader.instance().generate_vite_legacy_asset(
         path, **kwargs
     )
+
+@register.simple_tag
+@mark_safe
+def vite_react_refresh() -> str:
+    return DjangoViteAssetLoader.generate_vite_react_refresh_url()

--- a/django_vite/templatetags/django_vite.py
+++ b/django_vite/templatetags/django_vite.py
@@ -404,14 +404,24 @@ class DjangoViteAssetLoader:
             f"{DJANGO_VITE_DEV_SERVER_HOST}:{DJANGO_VITE_DEV_SERVER_PORT}",
             urljoin(DJANGO_VITE_STATIC_URL, path),
         )
-    
+
     @classmethod
     def generate_vite_react_refresh_url(cls) -> str:
+        """
+        Generates the script for the Vite React Refresh for HMR.
+        Only used in development, in production this method returns
+        an empty string.
+
+        Returns:
+            str -- The script or an empty string.
+        """
+
         if not DJANGO_VITE_DEV_MODE:
             return ""
 
         return f"""<script type="module">
-            import RefreshRuntime from '{cls._generate_vite_server_url(DJANGO_VITE_REACT_REFRESH_URL)}'
+            import RefreshRuntime from \
+            '{cls._generate_vite_server_url(DJANGO_VITE_REACT_REFRESH_URL)}'
             RefreshRuntime.injectIntoGlobalHook(window)
             window.$RefreshReg$ = () => {{}}
             window.$RefreshSig$ = () => (type) => type
@@ -555,7 +565,16 @@ def vite_legacy_asset(
         path, **kwargs
     )
 
+
 @register.simple_tag
 @mark_safe
 def vite_react_refresh() -> str:
+    """
+    Generates the script for the Vite React Refresh for HMR.
+    Only used in development, in production this method returns
+    an empty string.
+
+    Returns:
+        str -- The script or an empty string.
+    """
     return DjangoViteAssetLoader.generate_vite_react_refresh_url()


### PR DESCRIPTION
This PR adds a template tag called `vite_react_refresh` to handle providing the extra code needed to support react hot module reloading. 

This was discussed a bit in #14 and #15 and while it is project specific and only relevant for react users, having this tag be part of the package is inline with other framework community adapters like [Vite Rails](https://vite-ruby.netlify.app/guide/troubleshooting.html#hot-module-refresh-does-not-work-for-react) and [Vite Laravel](https://laravel.com/docs/9.x/vite#react)

I wasn't sure how'd you like to format the multi-line string needed, but since it's dev only I figured the indenting didn't matter much. If you disagree, let me know and I'll revise it!

Thanks for this great repo!