### PR TITLE
preloading shared imports as part of tag generation

### DIFF
--- a/django_vite/templatetags/django_vite.py
+++ b/django_vite/templatetags/django_vite.py
@@ -139,6 +139,24 @@ class DjangoViteAssetLoader:
             )
         )
 
+        # Preload imports
+        preload_attrs = {
+            "type": "text/javascript",
+            "crossorigin": "anonymous",
+            "rel": "modulepreload",
+            "as": "script",
+        }
+
+        for dep in manifest_entry.get("imports", []):
+            dep_manifest_entry = self._manifest[dep]
+            dep_file = dep_manifest_entry["file"]
+            tags.append(
+                DjangoViteAssetLoader._generate_preload_tag(
+                    urljoin(DJANGO_VITE_STATIC_URL, dep_file),
+                    attrs=preload_attrs,
+                )
+            )
+
         return "\n".join(tags)
 
     def _generate_css_files_of_asset(
@@ -382,6 +400,14 @@ class DjangoViteAssetLoader:
         """
 
         return f'<link rel="stylesheet" href="{href}" />'
+
+    @staticmethod
+    def _generate_preload_tag(href: str, attrs: Dict[str, str]) -> str:
+        attrs_str = " ".join(
+            [f'{key}="{value}"' for key, value in attrs.items()]
+        )
+
+        return f'<link href="{href}" {attrs_str} />'
 
     @staticmethod
     def _generate_vite_server_url(path: str) -> str:


### PR DESCRIPTION
Stealing a feature from ruby_vite (https://github.com/ElMassimo/vite_ruby/blob/3d8b3668b2f43dacbaf09127fa67a27767e03ffe/vite_rails/lib/vite_rails/tag_helpers.rb#L78  documented at https://vite-ruby.netlify.app/guide/rails.html#smart-output-%E2%9C%A8)

This will add the js dependencies specified in the manifest under link as module preload statements at the time of original rendering, so that the browser can opportunistically load before running the js. 