### PR TITLE
Allow : in bundle names

### DIFF
--- a/django_vite/templatetags/django_vite.py
+++ b/django_vite/templatetags/django_vite.py
@@ -398,7 +398,7 @@ class DjangoViteAssetLoader:
         return urljoin(
             f"{DJANGO_VITE_DEV_SERVER_PROTOCOL}://"
             f"{DJANGO_VITE_DEV_SERVER_HOST}:{DJANGO_VITE_DEV_SERVER_PORT}",
-            urljoin(DJANGO_VITE_STATIC_URL, path),
+            urljoin(DJANGO_VITE_STATIC_URL, "./" + path),
         )
 
 


### PR DESCRIPTION
This is needed e.g. for rollup-plugin-virtual, which prefixes bundle names with `virtual:`.

Relevant standard: https://www.rfc-editor.org/rfc/rfc3986#section-4.2

> A path segment that contains a colon character (e.g., "this:that")
> cannot be used as the first segment of a relative-path reference, as
> it would be mistaken for a scheme name.  Such a segment must be
> preceded by a dot-segment (e.g., "./this:that") to make a relative-
> path reference.