### PR TITLE
Add license information to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     long_description_content_type="text/markdown",
     author="MrBin99",
     url="https://github.com/MrBin99/django-vite",
+    license="Apache License, Version 2.0",
     include_package_data=True,
     packages=find_packages(),
     requires=[
@@ -23,6 +24,9 @@ setup(
     ],
     install_requires=[
         "Django>=1.11",
+    ],
+    classifiers=[
+        "License :: OSI Approved :: Apache Software License",
     ],
     extras_require={"dev": ["black", "flake8"]},
 )


### PR DESCRIPTION
Hello, my friend!

Commands such as `pip show django-vite` or `pip-licenses -p django-vite` show UNKNOWN in License section.
![изображение](https://user-images.githubusercontent.com/2499169/215759235-4d12ec42-2b0c-4c30-8d9b-8c74d0ce2a61.png)

We should place django-vite to ignore list when ci pipeline automatically checks license status of the bundle. Suggested changes probably will fix this behavior.

Good luck!