### PR TITLE
Add specific error for missing manifest

### DIFF
--- a/django_vite/templatetags/django_vite.py
+++ b/django_vite/templatetags/django_vite.py
@@ -123,7 +123,12 @@ class DjangoViteAssetLoader:
                 {"type": "module", **kwargs},
             )
 
-        if not self._manifest or path not in self._manifest:
+        if not self._manifest:
+            raise RuntimeError(
+                f"Cannot find Vite manifest at {DJANGO_VITE_MANIFEST_PATH}"
+            )
+
+        if path not in self._manifest:
             raise RuntimeError(
                 f"Cannot find {path} in Vite manifest "
                 f"at {DJANGO_VITE_MANIFEST_PATH}"


### PR DESCRIPTION
This PR introduces a more verbose error message for the case when the manifest file cannot be found. Currently it's impossible to tell if the manifest file / path itself wasn't found, or if the path within the manifest wasn't found. 

If you're using a custom manifest path / name this could trip you up, so giving a more specific error message will aid in debugging.