### PR TITLE
Only append `/` when `DJANGO_VITE_STATIC_URL_PREFIX` is provided (fixes #81)

### DIFF
--- a/django_vite/templatetags/django_vite.py
+++ b/django_vite/templatetags/django_vite.py
@@ -456,10 +456,11 @@ class DjangoViteAssetLoader:
             str -- Full URL to the asset.
         """
 
-        prefix = DJANGO_VITE_STATIC_URL_PREFIX
-        if not DJANGO_VITE_STATIC_URL_PREFIX.endswith("/"):
-            prefix += "/"
-        production_server_url = urljoin(prefix, path)
+        production_server_url = path
+        if prefix := DJANGO_VITE_STATIC_URL_PREFIX:
+            if not DJANGO_VITE_STATIC_URL_PREFIX.endswith("/"):
+                prefix += "/"
+            production_server_url = urljoin(prefix, path)
 
         if apps.is_installed("django.contrib.staticfiles"):
             from django.contrib.staticfiles.storage import staticfiles_storage


### PR DESCRIPTION
This PR modifies the logic that adds a `/` to the end of the `DJANGO_VITE_STATIC_URL_PREFIX` if it does not end with `/`.

This fixes an issue where a `/` will be added to the start of `production_server_url` if you didn't provide `DJANGO_VITE_STATIC_URL_PREFIX`.