### PR TITLE
Add kwargs support to vite_react_refresh

### DIFF
--- a/django_vite/templatetags/django_vite.py
+++ b/django_vite/templatetags/django_vite.py
@@ -540,11 +540,15 @@ class DjangoViteAssetLoader:
         )
 
     @classmethod
-    def generate_vite_react_refresh_url(cls) -> str:
+    def generate_vite_react_refresh_url(cls, **kwargs) -> str:
         """
         Generates the script for the Vite React Refresh for HMR.
         Only used in development, in production this method returns
         an empty string.
+
+        Keyword Arguments:
+            **kwargs {Dict[str, str]} -- Adds new attributes to generated
+                script tags.
 
         Returns:
             str -- The script or an empty string.
@@ -553,7 +557,9 @@ class DjangoViteAssetLoader:
         if not DJANGO_VITE_DEV_MODE:
             return ""
 
-        return f"""<script type="module">
+        attrs_str = " ".join([f'{key}="{value}"' for key, value in kwargs.items()])
+
+        return f"""<script type="module" {attrs_str}>
             import RefreshRuntime from \
             '{cls._generate_vite_server_url(DJANGO_VITE_REACT_REFRESH_URL)}'
             RefreshRuntime.injectIntoGlobalHook(window)
@@ -750,13 +756,17 @@ def vite_legacy_asset(
 
 @register.simple_tag
 @mark_safe
-def vite_react_refresh() -> str:
+def vite_react_refresh(**kwargs: Dict[str, str]) -> str:
     """
     Generates the script for the Vite React Refresh for HMR.
     Only used in development, in production this method returns
     an empty string.
 
+    Keyword Arguments:
+        **kwargs {Dict[str, str]} -- Adds new attributes to generated
+            script tags.
+
     Returns:
         str -- The script or an empty string.
     """
-    return DjangoViteAssetLoader.generate_vite_react_refresh_url()
+    return DjangoViteAssetLoader.generate_vite_react_refresh_url(**kwargs)

--- a/tests/tests/templatetags/test_vite_react_refresh.py
+++ b/tests/tests/templatetags/test_vite_react_refresh.py
@@ -72,3 +72,18 @@ def test_vite_react_refresh_url_setting(patch_settings):
     soup = BeautifulSoup(html, "html.parser")
     script_tag = soup.script
     assert "http://localhost:3000/static/foobar" in script_tag.text
+
+
+def test_vite_react_refresh_uses_kwargs(patch_settings):
+    patch_settings({"DJANGO_VITE_REACT_REFRESH_URL": "foobar"})
+    template = Template(
+        """
+        {% load django_vite %}
+        {% vite_react_refresh nonce="woo-nonce" %}
+    """
+    )
+    html = template.render(Context({}))
+    soup = BeautifulSoup(html, "html.parser")
+    script_tag = soup.script
+    assert script_tag.has_attr("nonce")
+    assert script_tag["nonce"] == "woo-nonce"


### PR DESCRIPTION
This feature allows `vite_react_refresh` to be configured with script attributes like the other templatetags, allowing for example the configuration of a CSP nonce.

Closes https://github.com/MrBin99/django-vite/issues/89