### PR TITLE
include '-' in example whitenoise regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ import re
 def immutable_file_test(path, url):
     # Match filename with 12 hex digits before the extension
     # e.g. app.db8f2edc0c8a.js
-    return re.match(r"^.+\.[0-9a-f]{8,12}\..+$", url)
+    return re.match(r"^.+[\.\-][0-9a-f]{8,12}\..+$", url)
 
 
 WHITENOISE_IMMUTABLE_FILE_TEST = immutable_file_test


### PR DESCRIPTION
fixes https://github.com/MrBin99/django-vite/issues/93