### PR TITLE
fix: stop loading unsupported attributes into ManifestEntry

### DIFF
--- a/django_vite/core/asset_loader.py
+++ b/django_vite/core/asset_loader.py
@@ -59,8 +59,10 @@ class ManifestEntry(NamedTuple):
     file: str
     src: Optional[str] = None
     isEntry: Optional[bool] = False
+    isDynamicEntry: Optional[bool] = False
     css: Optional[List[str]] = []
     imports: Optional[List[str]] = []
+    dynamicImports: Optional[List[str]] = []
 
 
 class ManifestClient:
@@ -166,7 +168,12 @@ class ManifestClient:
                 manifest_json = json.loads(manifest_content)
 
                 for path, manifest_entry_data in manifest_json.items():
-                    manifest_entry = ManifestEntry(**manifest_entry_data)
+                    filtered_manifest_entry_data = {
+                        key: value
+                        for key, value in manifest_entry_data.items()
+                        if key in ManifestEntry._fields
+                    }
+                    manifest_entry = ManifestEntry(**filtered_manifest_entry_data)
                     entries[path] = manifest_entry
                     if self.legacy_polyfills_motif in path:
                         legacy_polyfills_entry = manifest_entry

--- a/tests/data/staticfiles/dynamic-entry-manifest.json
+++ b/tests/data/staticfiles/dynamic-entry-manifest.json
@@ -1,0 +1,19 @@
+{
+    "main.js": {
+      "file": "assets/main.4889e940.js",
+      "src": "main.js",
+      "isEntry": true,
+      "dynamicImports": ["views/foo.js"],
+      "css": ["assets/main.b82dbe22.css"],
+      "assets": ["assets/asset.0ab0f9cd.png"]
+    },
+    "views/foo.js": {
+      "file": "assets/foo.869aea0d.js",
+      "src": "views/foo.js",
+      "isDynamicEntry": true,
+      "imports": ["_shared.83069a53.js"]
+    },
+    "_shared.83069a53.js": {
+      "file": "assets/shared.83069a53.js"
+    }
+}

--- a/tests/tests/test_asset_loader.py
+++ b/tests/tests/test_asset_loader.py
@@ -126,3 +126,25 @@ def test_parse_manifest_during_dev_mode(dev_mode_true):
     default_app = DjangoViteAssetLoader.instance()._apps["default"]
     manifest_client = default_app.manifest
     assert manifest_client._parse_manifest() == manifest_client.ParsedManifestOutput()
+
+
+@pytest.mark.parametrize(
+    "patch_settings",
+    [
+        {
+            "DJANGO_VITE_DEV_MODE": False,
+            "DJANGO_VITE_MANIFEST_PATH": "dynamic-entry-manifest.json",
+        },
+        {
+            "DJANGO_VITE": {
+                "default": {
+                    "dev_mode": False,
+                    "manifest_path": "dynamic-entry-manifest.json",
+                }
+            }
+        },
+    ],
+)
+def test_load_dynamic_import_manifest(patch_settings):
+    warnings = check_loader_instance()
+    assert len(warnings) == 0


### PR DESCRIPTION
fixes https://github.com/MrBin99/django-vite/issues/100

django-vite v3's `ManifestEntry` is now a NamedTuple instead of a dict. So if there were any attributes in a manifest.json entry that were not explicitly named in `ManifestEntry`, it would throw an error.

- **Fixes**: adds `isDynamicEntry` and `dynamicImports` to `ManifestEntry`.
- **Changed**: also filters the data we insert into ManifestEntry so that only supported keys are loaded in, to prevent this from happening in the future.