### PR TITLE
Fix explosion of `already_processed`

### DIFF
--- a/django_vite/core/asset_loader.py
+++ b/django_vite/core/asset_loader.py
@@ -449,23 +449,22 @@ class DjangoViteAppClient:
             tags -- List of CSS tags.
             already_processed -- List of already processed css paths
         """
-        already_processed = already_processed or []
+        if already_processed is None:
+            already_processed = []
         tags: List[Tag] = []
         manifest_entry = self.manifest.get(path)
 
         for import_path in manifest_entry.imports:
-            new_tags, new_already_processed = self._generate_css_files_of_asset(
+            new_tags, _ = self._generate_css_files_of_asset(
                 import_path, already_processed, tag_generator
             )
             tags.extend(new_tags)
-            already_processed.extend(new_already_processed)
 
         for css_path in manifest_entry.css:
             if css_path not in already_processed:
                 url = self._get_production_server_url(css_path)
                 tags.append(tag_generator(url))
-
-            already_processed.append(css_path)
+                already_processed.append(css_path)
 
         return self.GeneratedCssFilesOutput(tags, already_processed)
 


### PR DESCRIPTION
`already_processed` was unnecessarily appended and extended during CSS tags generation.

It was repeatedly calling `a.extend(a)` causing memory explosion. With my app's assets it quickly went to 16 GB and caused my Django process to be OOM killed.

You can test this behavior:
```
>>> a = list(f'some-hashed-path-{i}' for i in range(100))
>>> for j in range(100):
...     print(f'Iteration {j}')
...     a.extend(a)
... 
Iteration 0
Iteration 1
Iteration 2
Iteration 3
Iteration 4
Iteration 5
Iteration 6
Iteration 7
Iteration 8
Iteration 9
Iteration 10
Iteration 11
Iteration 12
Iteration 13
Iteration 14
Iteration 15
Iteration 16
Iteration 17
Iteration 18
Iteration 19
Iteration 20
Iteration 21
Iteration 22
Iteration 23
Iteration 24
Killed
```