### PR TITLE
Add .vite directory in manifest.json path

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ export default defineConfig({
 
 ### manifest_path
 - **Type**: `str | Path`
-- **Default**: `Path(settings.STATIC_ROOT) / static_url_prefix / "manifest.json"`
+- **Default**: `Path(settings.STATIC_ROOT) / static_url_prefix / ".vite" / "manifest.json"`
 - **Legacy Key**: `DJANGO_VITE_MANIFEST_PATH`
 
 The absolute path, including the filename, to the ViteJS manifest file located in `build.outDir`.

--- a/django_vite/core/asset_loader.py
+++ b/django_vite/core/asset_loader.py
@@ -100,7 +100,7 @@ class ManifestClient:
         """
         Get the manifest_path from the config.
         If it wasn't provided, set the default location to
-        STATIC_ROOT / static_url_prefix / "manifest.json".
+        STATIC_ROOT / static_url_prefix / ".vite" / "manifest.json".
 
         Returns:
             Path -- the path to the vite config's manifest.json
@@ -110,6 +110,7 @@ class ManifestClient:
             return (
                 Path(settings.STATIC_ROOT)
                 / self._config.static_url_prefix
+                / ".vite"
                 / "manifest.json"
             )
         elif not isinstance(initial_manifest_path, Path):


### PR DESCRIPTION
Vite version 5 changed the path of the generated `manifest.json` file. It now generates it in a `.vite` directory.
https://vitejs.dev/guide/migration#manifest-files-are-now-generated-in-vite-directory-by-default