### PR TITLE
support kebab casing in vite_asset template tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,24 @@ If you want to overrides default attributes just add them like new attributes :
 
 Although it's recommended to keep the default `type="module"` attribute as ViteJS build scripts as ES6 modules.
 
+You can also set attributes that require `kebab-casing` by padding `json_encoded_attributes`.
+
+```python
+from django.utils.safestring import SafeString
+
+def your_view(request):
+  json_encoded_attributes = json.dumps({
+    "some-item": "3",
+    "some-other-item": "value",
+  })
+
+  render(request, template, context={ "json_encoded_attributes": SafeString(json_encoded_attributes) })
+```
+
+```html
+{% vite_asset '<path to your asset>' json_encoded_attributes=json_encoded_attributes %}
+```
+
 ## Vite Legacy Plugin
 
 If you want to consider legacy browsers that don't support ES6 modules loading

--- a/django_vite/core/asset_loader.py
+++ b/django_vite/core/asset_loader.py
@@ -302,6 +302,10 @@ class DjangoViteAppClient:
                 this asset in your page.
         """
 
+        json_encoded_attributes = kwargs.pop("json_encoded_attributes", "{}")
+        json_encoded_attributes = json.loads(json_encoded_attributes)
+        kwargs.update(json_encoded_attributes)
+
         if self.dev_mode:
             url = self._get_dev_server_url(path)
             return TagGenerator.script(

--- a/tests/tests/templatetags/test_vite_asset.py
+++ b/tests/tests/templatetags/test_vite_asset.py
@@ -220,10 +220,13 @@ def test_vite_asset_kebab_attribute():
         """
         {% load django_vite %}
         {% vite_asset "src/entry.ts" json_encoded_attributes=json_encoded_attributes %}
-    """)
-    html = template.render(Context({
-        "json_encoded_attributes": SafeString(json.dumps(additional_attributes))
-    }))
+    """
+    )
+    html = template.render(
+        Context(
+            {"json_encoded_attributes": SafeString(json.dumps(additional_attributes))}
+        )
+    )
     soup = BeautifulSoup(html, "html.parser")
     script_tag = soup.find("script")
     assert script_tag["data-item-track"] == "reload"

--- a/tests/tests/templatetags/test_vite_asset.py
+++ b/tests/tests/templatetags/test_vite_asset.py
@@ -1,4 +1,6 @@
 import pytest
+from django.utils.safestring import SafeString
+import json
 from bs4 import BeautifulSoup
 from django.template import Context, Template, TemplateSyntaxError
 from django_vite.core.exceptions import (
@@ -206,6 +208,26 @@ def test_vite_asset_override_default_attribute():
     soup = BeautifulSoup(html, "html.parser")
     script_tag = soup.find("script")
     assert script_tag["crossorigin"] == "anonymous"
+
+
+@pytest.mark.usefixtures("dev_mode_all")
+def test_vite_asset_kebab_attribute():
+    additional_attributes = {
+        "data-item-track": "reload",
+        "data-other": "3",
+    }
+    template = Template(
+        """
+        {% load django_vite %}
+        {% vite_asset "src/entry.ts" json_encoded_attributes=json_encoded_attributes %}
+    """)
+    html = template.render(Context({
+        "json_encoded_attributes": SafeString(json.dumps(additional_attributes))
+    }))
+    soup = BeautifulSoup(html, "html.parser")
+    script_tag = soup.find("script")
+    assert script_tag["data-item-track"] == "reload"
+    assert script_tag["data-other"] == "3"
 
 
 def test_vite_asset_custom_attributes(dev_mode_all):


### PR DESCRIPTION
Attributes can be set on the entry script tag by using the following syntax:

```
{% vite_asset '<path to your asset>' foo="bar" hello="world" %}
```

However, this does not allow for `kebab-cased` attributes. We are using a framework that [requires we set](https://turbo.hotwired.dev/handbook/drive#reloading-when-assets-change) the data attribute `data-turbo-track="reload"` on the entry `<script />`. 

Since `kebab-cased` attributes cannot be supported via `kwargs`, `vite_asset` has been updated to support JSON encoded attributes:

```python
from django.utils.safestring import SafeString

def your_view(request):
  json_encoded_attributes = json.dumps({
    "some-item": "3",
    "some-other-item": "value",
  })

  render(request, template, context={ "json_encoded_attributes": SafeString(json_encoded_attributes) })
```

```html
{% vite_asset '<path to your asset>' json_encoded_attributes=json_encoded_attributes %}
```

Closes https://github.com/MrBin99/django-vite/issues/127