### PR TITLE
:memo: Fixes script attribute documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,7 @@ Then add this tag (in your `<head>` element too) to load your scripts :
 
 This will add a `<script>` tag including your JS/TS script :
 
-- In development mode, all scripts are included as modules.
-- In development mode, all scripts are marked as `async` and `defer`.
+- In development and production, all scripts are included as modules (`[type=module]`).
 - You can pass a second argument to this tag to overrides attributes
   passed to the script tag.
 - This tag only accept JS/TS, for other type of assets, they must be


### PR DESCRIPTION
Was a bit curious when checking out this project about the `async` and `defer` since you should never have both (just `defer` is best).

But turns out, it's just always `type=module` which is an implicit `defer`.

Was fun poking around to see how things work.