### PR TITLE
Make attributes set by the user propagate to all assets

### DIFF
--- a/django_vite/core/tag_generator.py
+++ b/django_vite/core/tag_generator.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 
 Tag = str
 
@@ -36,7 +36,7 @@ class TagGenerator:
         return f'<script {attrs_str} src="{src}"></script>'
 
     @staticmethod
-    def stylesheet(href: str) -> Tag:
+    def stylesheet(href: str, attrs: Optional[Dict[str, str]] = None) -> Tag:
         """
         Generates an HTML <link> stylesheet tag for CSS.
 
@@ -47,10 +47,12 @@ class TagGenerator:
             str -- CSS link tag.
         """
 
-        return f'<link rel="stylesheet" href="{href}" />'
+        attrs_str = attrs_to_str(attrs)
+
+        return f'<link {attrs_str} rel="stylesheet" href="{href}" />'
 
     @staticmethod
-    def stylesheet_preload(href: str) -> Tag:
+    def stylesheet_preload(href: str, attrs: Optional[Dict[str, str]] = None) -> Tag:
         """
         Generates an HTML <link> preload tag for CSS.
 
@@ -61,7 +63,9 @@ class TagGenerator:
             str -- CSS link tag.
         """
 
-        return f'<link rel="preload" href="{href}" as="style" />'
+        attrs_str = attrs_to_str(attrs)
+
+        return f'<link {attrs_str} rel="preload" href="{href}" as="style" />'
 
     @staticmethod
     def preload(href: str, attrs: Dict[str, str]) -> Tag:

--- a/django_vite/core/tag_generator.py
+++ b/django_vite/core/tag_generator.py
@@ -47,7 +47,7 @@ class TagGenerator:
             str -- CSS link tag.
         """
 
-        attrs_str = attrs_to_str(attrs)
+        attrs_str = attrs_to_str(attrs if attrs else {})
 
         return f'<link {attrs_str} rel="stylesheet" href="{href}" />'
 
@@ -63,7 +63,7 @@ class TagGenerator:
             str -- CSS link tag.
         """
 
-        attrs_str = attrs_to_str(attrs)
+        attrs_str = attrs_to_str(attrs if attrs else {})
 
         return f'<link {attrs_str} rel="preload" href="{href}" as="style" />'
 

--- a/tests/tests/templatetags/test_vite_asset.py
+++ b/tests/tests/templatetags/test_vite_asset.py
@@ -218,9 +218,14 @@ def test_vite_asset_kebab_attribute():
     )
     html = template.render(Context({}))
     soup = BeautifulSoup(html, "html.parser")
-    script_tag = soup.find("script")
-    assert script_tag["data-item-track"] == "reload"
-    assert script_tag["data-other"] == "3"
+
+    for script_tag in soup.find_all("script"):
+        assert script_tag["data-item-track"] == "reload"
+        assert script_tag["data-other"] == "3"
+
+    for link in soup.find_all("link"):
+        assert link["data-item-track"] == "reload"
+        assert link["data-other"] == "3"
 
 
 def test_vite_asset_custom_attributes(dev_mode_all):


### PR DESCRIPTION
Closes: https://github.com/MrBin99/django-vite/issues/140

This is a followup to https://github.com/MrBin99/django-vite/pull/131 and https://github.com/MrBin99/django-vite/pull/128. 

Django-vite now supports kebab cased attributes:

```
{% vite_asset '<path to your asset>' foo="bar" data_my_custom_attribute="world" %}
```

However, these attributes are not propagated to all tags that are generated by `vite_asset`. 

My organization relies on [Turbo's `data-turbo-track="reload"` attribute](https://turbo.hotwired.dev/handbook/drive#reloading-when-assets-change). When a new HTML file is fetched from the server, Turbo will know that it should perform a reload if there's a Js/CSS/etc file with a URL that it hasn't previously loaded.

This attribute needs to be set on every asset that we load in using `{% vite_asset 'app/main.ts' ... %}`.

This PR propagates user-defined attributes to all tags generated by `vite_asset`.

**Before**

```
{% vite_asset "src/entry.ts" data_item_track="reload" data_other="3" %}
...
<link rel="stylesheet" href="assets/entry-74d0d5dd.css" />
<script type="module" crossorigin="" data-item-track="reload" data-other="3" src="assets/entry-29e38a60.js"></script>
```

**After**

```
{% vite_asset "src/entry.ts" data_item_track="reload" data_other="3" %}
...
<link data-item-track="reload" data-other="3" rel="stylesheet" href="assets/entry-74d0d5dd.css" />
<script type="module" crossorigin="" data-item-track="reload" data-other="3" src="assets/entry-29e38a60.js"></script>
```