### PR TITLE
Fix lint issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,10 @@ repos:
     hooks:
       - id: "commitizen"
         stages: ["commit-msg"]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.2
+    hooks:
+      - id: ruff
+        args:
+          - --fix

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,11 +9,6 @@ repos:
         args: ["--fix=lf"]
       - id: "trailing-whitespace"
 
-  - repo: "https://github.com/psf/black"
-    rev: "23.3.0"
-    hooks:
-      - id: "black"
-
   - repo: "https://github.com/commitizen-tools/commitizen"
     rev: "v3.13.0"
     hooks:
@@ -26,3 +21,4 @@ repos:
       - id: ruff
         args:
           - --fix
+      - id: ruff-format

--- a/django_vite/__init__.py
+++ b/django_vite/__init__.py
@@ -1,4 +1,3 @@
 from .core.asset_loader import DjangoViteConfig
 
-
 __all__ = ["DjangoViteConfig"]

--- a/django_vite/core/asset_loader.py
+++ b/django_vite/core/asset_loader.py
@@ -758,6 +758,7 @@ class DjangoViteAssetLoader:
                 f"settings will be ignored since you have a {cls.DJANGO_VITE}"
                 " setting configured. Please remove those legacy django-vite settings.",
                 DeprecationWarning,
+                stacklevel=2,
             )
             return
 
@@ -767,6 +768,7 @@ class DjangoViteAssetLoader:
             "in future releases of django-vite. Please switch to defining your "
             f'settings as {cls.DJANGO_VITE} = {{"default": {{...}},}}.',
             DeprecationWarning,
+            stacklevel=2,
         )
 
         legacy_config = {}

--- a/django_vite/core/asset_loader.py
+++ b/django_vite/core/asset_loader.py
@@ -1,8 +1,8 @@
 import json
-from pathlib import Path
-from typing import Dict, List, Callable, NamedTuple, Optional, Union, Set
-from urllib.parse import urljoin
 import warnings
+from pathlib import Path
+from typing import Callable, Dict, List, NamedTuple, Optional, Set, Union
+from urllib.parse import urljoin
 
 from django.apps import apps
 from django.conf import settings
@@ -10,9 +10,9 @@ from django.core.checks import Warning
 from django.utils.module_loading import import_string
 
 from django_vite.core.exceptions import (
-    DjangoViteManifestError,
     DjangoViteAssetNotFoundError,
     DjangoViteConfigNotFoundError,
+    DjangoViteManifestError,
 )
 from django_vite.core.tag_generator import Tag, TagGenerator, attrs_to_str
 

--- a/django_vite/templatetags/django_vite.py
+++ b/django_vite/templatetags/django_vite.py
@@ -3,8 +3,7 @@ from typing import Dict
 from django import template
 from django.utils.safestring import mark_safe
 
-from django_vite.core.asset_loader import DjangoViteAssetLoader, DEFAULT_APP_NAME
-
+from django_vite.core.asset_loader import DEFAULT_APP_NAME, DjangoViteAssetLoader
 
 register = template.Library()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ addopts = '''
 '''
 filterwarnings = "ignore::DeprecationWarning:django_vite.*"
 
-[tool.black]
+[tool.ruff]
 line-length = 88
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ filterwarnings = "ignore::DeprecationWarning:django_vite.*"
 [tool.black]
 line-length = 88
 
-[tool.ruff]
+[tool.ruff.lint]
 select = [
   "E",   # pycodestyle
   "F",   # pyflakes
@@ -23,6 +23,12 @@ select = [
   "SIM", # simplify,
   "DJ",  # django,
   "I",   # isort
+]
+
+ignore = [
+  "E501",   # line too long (taken care of by formatter)
+  "PT012",  # multiple statements in `pytest.raises` (TODO: fix?)
+  "SIM105", # `contextlib.suppress` is slower than try-except, so do not suggest it
 ]
 
 # do not autofix the following violations due to bad DX:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def reload_django_vite():
     DjangoViteAssetLoader.instance()
 
 
-@pytest.fixture()
+@pytest.fixture
 def patch_settings(request, settings):
     """
     1. Patch new settings into django.conf.settings.
@@ -47,14 +47,14 @@ def patch_settings(request, settings):
     reload_django_vite()
 
 
-@pytest.fixture()
+@pytest.fixture
 def delete_settings(patch_settings):
     """
     Unset settings that are part of the default test settings.py
     """
 
     def _delete_settings(*settings_to_delete: str):
-        new_settings = {key: __PYTEST_DELETE__ for key in settings_to_delete}
+        new_settings = dict.fromkeys(settings_to_delete, __PYTEST_DELETE__)
         return patch_settings(new_settings)
 
     return _delete_settings

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
-from typing import Dict, Any
+from typing import Any, Dict
+
 import pytest
 
 from django_vite.core.asset_loader import DjangoViteAssetLoader

--- a/tests/tests/templatetags/test_vite_asset.py
+++ b/tests/tests/templatetags/test_vite_asset.py
@@ -1,8 +1,10 @@
+from pathlib import Path
+
 import pytest
 from bs4 import BeautifulSoup
-from pathlib import Path
 from django.conf import settings
 from django.template import Context, Template, TemplateSyntaxError
+
 from django_vite.core.exceptions import (
     DjangoViteAssetNotFoundError,
     DjangoViteConfigNotFoundError,

--- a/tests/tests/templatetags/test_vite_asset.py
+++ b/tests/tests/templatetags/test_vite_asset.py
@@ -259,7 +259,7 @@ def test_vite_asset_nonexistent_app(dev_mode_true):
     assert "Cannot find bad_app in DJANGO_VITE settings" in str(error)
 
 
-@pytest.fixture()
+@pytest.fixture
 def external_vue_app(patch_settings, settings):
     def _wrapper(dev_mode: bool):
         return patch_settings(

--- a/tests/tests/templatetags/test_vite_asset_url.py
+++ b/tests/tests/templatetags/test_vite_asset_url.py
@@ -1,6 +1,7 @@
 import pytest
 from bs4 import BeautifulSoup
 from django.template import Context, Template
+
 from django_vite.core.exceptions import DjangoViteAssetNotFoundError
 
 

--- a/tests/tests/templatetags/test_vite_legacy_asset.py
+++ b/tests/tests/templatetags/test_vite_legacy_asset.py
@@ -1,6 +1,7 @@
 import pytest
 from bs4 import BeautifulSoup
 from django.template import Context, Template
+
 from django_vite.core.exceptions import DjangoViteAssetNotFoundError
 
 

--- a/tests/tests/templatetags/test_vite_legacy_polyfills.py
+++ b/tests/tests/templatetags/test_vite_legacy_polyfills.py
@@ -1,6 +1,7 @@
 import pytest
 from bs4 import BeautifulSoup
 from django.template import Context, Template
+
 from django_vite.core.exceptions import DjangoViteAssetNotFoundError
 
 

--- a/tests/tests/templatetags/test_vite_preload_asset.py
+++ b/tests/tests/templatetags/test_vite_preload_asset.py
@@ -1,6 +1,7 @@
 import pytest
 from bs4 import BeautifulSoup
 from django.template import Context, Template
+
 from django_vite.core.exceptions import DjangoViteAssetNotFoundError
 
 

--- a/tests/tests/test_asset_loader.py
+++ b/tests/tests/test_asset_loader.py
@@ -1,13 +1,13 @@
-import pytest
-
-from django_vite.core.asset_loader import (
-    DjangoViteConfig,
-    DjangoViteAssetLoader,
-)
 from pathlib import Path
+
+import pytest
 from django.conf import settings
-from django_vite.core.asset_loader import DjangoViteConfig
+
 from django_vite.apps import check_loader_instance
+from django_vite.core.asset_loader import (
+    DjangoViteAssetLoader,
+    DjangoViteConfig,
+)
 
 
 def test_django_vite_asset_loader_cannot_be_instantiated():

--- a/tests/tests/test_asset_loader.py
+++ b/tests/tests/test_asset_loader.py
@@ -127,12 +127,6 @@ def test_parse_manifest_during_dev_mode(dev_mode_true):
     assert manifest_client._parse_manifest() == manifest_client.ParsedManifestOutput()
 
 
-def test_parse_manifest_during_dev_mode(dev_mode_true):
-    default_app = DjangoViteAssetLoader.instance()._apps["default"]
-    manifest_client = default_app.manifest
-    assert manifest_client._parse_manifest() == manifest_client.ParsedManifestOutput()
-
-
 @pytest.mark.parametrize(
     "patch_settings",
     [

--- a/tox.ini
+++ b/tox.ini
@@ -58,11 +58,10 @@ ignore_outcome =
     django-latest: True
 
 [testenv:codestyle]
-basepython = python3
 commands =
-    black --check --diff .
+    ruff format --check --diff .
 deps =
-    black
+    ruff~=0.11.2
 skip_install = true
 
 [testenv:lint]

--- a/tox.ini
+++ b/tox.ini
@@ -69,5 +69,5 @@ skip_install = true
 commands =
     ruff check django_vite
 deps =
-    ruff
+    ruff~=0.11.2
 skip_install = true


### PR DESCRIPTION
This PR:

* pins the version of Ruff used in the repo and adds it to the `pre-commit` configuration as well
* fixes various issues flagged by Ruff 0.11.2 (automatically and by hand)
* switches the formatter used in the repo from `black` to `ruff format` (because Ruff is there anyway)

Since Ruff wasn't in the `pre-commit` configuration, and `tox-gh-actions` had filtered out tox envs that didn't match the GHA configuration, Ruff lints were never being run in CI. 