### PR TITLE
Add `vite_preload_assets` template tag for performance optimization

### DIFF
--- a/django_vite/core/asset_loader.py
+++ b/django_vite/core/asset_loader.py
@@ -1,4 +1,5 @@
 import json
+import mimetypes
 from pathlib import Path
 from typing import Dict, List, Callable, NamedTuple, Optional, Union, Set
 from urllib.parse import urljoin
@@ -68,6 +69,7 @@ class ManifestEntry(NamedTuple):
     css: Optional[List[str]] = []
     imports: Optional[List[str]] = []
     dynamicImports: Optional[List[str]] = []
+    assets: Optional[List[str]] = None
 
 
 class ManifestClient:
@@ -421,6 +423,40 @@ class DjangoViteAppClient:
             )
 
         return "\n".join(tags)
+
+    def generate_preload_assets_tags(
+        self, path: str, file_ext: str, as_type: str, **kwargs: Dict[str, str]
+    ) -> List[str]:
+        """
+        Generates <link rel="preload"> tags for assets of a given entry point.
+        """
+        if self.dev_mode:
+            return []
+
+        try:
+            entry = self.manifest.get(path)
+        except DjangoViteAssetNotFoundError:
+            return []
+
+        if not entry.assets:
+            return []
+
+        tags = []
+
+        for asset in entry.assets:
+            if asset.endswith(file_ext):
+                href = self.get_production_server_url(asset)
+                content_type, _ = mimetypes.guess_type(asset)
+
+                attrs = {"rel": "preload", "href": href, "as": as_type, **kwargs}
+
+                if content_type:
+                    attrs["type"] = content_type
+
+                tag = "<link " + " ".join(f'{k}="{v}"' for k, v in attrs.items()) + ">"
+                tags.append(tag)
+
+        return tags
 
     def _preload_css_files_of_asset(
         self, path: str, attrs: Optional[Dict[str, str]] = None
@@ -835,6 +871,20 @@ class DjangoViteAssetLoader:
     ) -> str:
         app_client = self._get_app_client(app)
         return app_client.generate_vite_asset_url(path)
+
+    def generate_vite_preload_assets(
+        self,
+        path: str,
+        file_ext: str,
+        as_type: str,
+        app: str = DEFAULT_APP_NAME,
+        **kwargs: Dict[str, str],
+    ) -> str:
+        app_client = self._get_app_client(app)
+        tags = app_client.generate_preload_assets_tags(
+            path, file_ext, as_type, **kwargs
+        )
+        return "\n".join(tags)
 
     def generate_vite_legacy_polyfills(
         self,

--- a/django_vite/templatetags/django_vite.py
+++ b/django_vite/templatetags/django_vite.py
@@ -200,3 +200,39 @@ def vite_react_refresh(
     return DjangoViteAssetLoader.instance().generate_vite_react_refresh_url(
         app, **kwargs
     )
+
+
+@register.simple_tag
+@mark_safe
+def vite_preload_assets(
+    path: str,
+    file_ext: str,
+    as_type: str,
+    app: str = DEFAULT_APP_NAME,
+    **kwargs: Dict[str, str],
+):
+    """
+    Generates <link rel="preload"> tags for assets of a given entry point.
+
+    Arguments:
+        path {str} -- Path to a Vite asset to include.
+        file_ext {str} -- File extension to filter assets by (e.g. 'woff2').
+            Used to specify which asset types to preload from the entry point.
+        as_type {str} -- Resource type for the 'as' attribute of the preload link
+            (e.g. 'font'). This tells the browser how to handle the resource.
+        app {str} -- Configuration to use.
+
+    Keyword Arguments:
+        **kwargs {Dict[str, str]} -- Additional attributes for the generated
+            link tags (e.g., crossorigin="anonymous").
+
+    Returns:
+        str -- The <link rel="preload"> tags for all assets under the specified entry
+    """
+    return DjangoViteAssetLoader.instance().generate_vite_preload_assets(
+        path,
+        file_ext=file_ext,
+        as_type=as_type,
+        app=app,
+        **kwargs,
+    )

--- a/tests/data/staticfiles/preload-assets-manifest.json
+++ b/tests/data/staticfiles/preload-assets-manifest.json
@@ -1,0 +1,18 @@
+{
+  "src/entry-with-assets.js": {
+    "file": "assets/entry-with-assets.12345.js",
+    "src": "src/entry-with-assets.js",
+    "isEntry": true,
+    "assets": [
+      "assets/font.woff2",
+      "assets/font.otf",
+      "assets/image.png",
+      "assets/data.unknown"
+    ]
+  },
+  "src/entry-without-assets.js": {
+    "file": "assets/entry-without-assets.67890.js",
+    "src": "src/entry-without-assets.js",
+    "isEntry": true
+  }
+}

--- a/tests/tests/templatetags/test_vite_preload_assets.py
+++ b/tests/tests/templatetags/test_vite_preload_assets.py
@@ -30,10 +30,12 @@ def patch_preload_settings(patch_settings):
 
 
 def test_preload_assets_ext_woff2_and_type_font():
-    template = Template("""
+    template = Template(
+        """
     {% load django_vite %}
     {% vite_preload_assets 'src/entry-with-assets.js' file_ext='.woff2' as_type='font' crossorigin='anonymous' %}
-    """)
+    """
+    )
     html = template.render(Context({}))
     soup = BeautifulSoup(html, "html.parser")
     link_tag = soup.find("link")
@@ -45,10 +47,12 @@ def test_preload_assets_ext_woff2_and_type_font():
 
 
 def test_preload_assets_ext_oft_and_type_font():
-    template = Template("""
+    template = Template(
+        """
     {% load django_vite %}
     {% vite_preload_assets 'src/entry-with-assets.js' file_ext='.otf' as_type='font' crossorigin='anonymous' %}
-    """)
+    """
+    )
     html = template.render(Context({}))
     soup = BeautifulSoup(html, "html.parser")
     link_tag = soup.find("link")
@@ -57,10 +61,12 @@ def test_preload_assets_ext_oft_and_type_font():
 
 
 def test_preload_assets_image():
-    template = Template("""
+    template = Template(
+        """
     {% load django_vite %}
     {% vite_preload_assets 'src/entry-with-assets.js' file_ext='.png' as_type='image' %}
-    """)
+    """
+    )
     html = template.render(Context({}))
     soup = BeautifulSoup(html, "html.parser")
     link_tag = soup.find("link")
@@ -71,37 +77,45 @@ def test_preload_assets_image():
 
 
 def test_entry_not_found():
-    template = Template("""
+    template = Template(
+        """
     {% load django_vite %}
     {% vite_preload_assets 'src/non-existent-entry.js' file_ext='.otf' as_type='font' %}
-    """)
+    """
+    )
     html = template.render(Context({}))
     assert html.strip() == ""
 
 
 def test_entry_without_assets():
-    template = Template("""
+    template = Template(
+        """
     {% load django_vite %}
     {% vite_preload_assets 'src/entry-without-assets.js' file_ext='.svg' as_type='image' %}
-    """)
+    """
+    )
     html = template.render(Context({}))
     assert html.strip() == ""
 
 
 def test_no_matching_assets():
-    template = Template("""
+    template = Template(
+        """
     {% load django_vite %}
     {% vite_preload_assets 'src/entry-with-assets.js' file_ext='.svg' as_type='image' %}
-    """)
+    """
+    )
     html = template.render(Context({}))
     assert html.strip() == ""
 
 
 def test_unknown_mimetype():
-    template = Template("""
+    template = Template(
+        """
     {% load django_vite %}
     {% vite_preload_assets 'src/entry-with-assets.js' file_ext='.unknown' as_type='object' %}
-    """)
+    """
+    )
     html = template.render(Context({}))
     soup = BeautifulSoup(html, "html.parser")
     link_tag = soup.find("link")

--- a/tests/tests/templatetags/test_vite_preload_assets.py
+++ b/tests/tests/templatetags/test_vite_preload_assets.py
@@ -1,0 +1,110 @@
+from pathlib import Path
+
+import pytest
+from bs4 import BeautifulSoup
+from django.conf import settings
+from django.template import Context, Template
+
+PRELOAD_MANIFEST_PATH = (
+    Path(settings.BASE_DIR) / "data/staticfiles/preload-assets-manifest.json"
+)
+
+
+@pytest.fixture(autouse=True)
+def patch_preload_settings(patch_settings):
+    return patch_settings(
+        {
+            "DJANGO_VITE": {
+                "default": {
+                    "dev_mode": False,
+                    "manifest_path": PRELOAD_MANIFEST_PATH,
+                    "static_url_prefix": "dist/",
+                }
+            },
+            "INSTALLED_APPS": [
+                "django_vite",
+                "django.contrib.staticfiles",
+            ],
+        }
+    )
+
+
+def test_preload_assets_ext_woff2_and_type_font():
+    template = Template("""
+    {% load django_vite %}
+    {% vite_preload_assets 'src/entry-with-assets.js' file_ext='.woff2' as_type='font' crossorigin='anonymous' %}
+    """)
+    html = template.render(Context({}))
+    soup = BeautifulSoup(html, "html.parser")
+    link_tag = soup.find("link")
+    assert link_tag["href"] == "/static/dist/assets/font.woff2"
+    assert link_tag["rel"] == ["preload"]
+    assert link_tag["as"] == "font"
+    assert link_tag["type"] == "font/woff2"
+    assert link_tag.has_attr("crossorigin")
+
+
+def test_preload_assets_ext_oft_and_type_font():
+    template = Template("""
+    {% load django_vite %}
+    {% vite_preload_assets 'src/entry-with-assets.js' file_ext='.otf' as_type='font' crossorigin='anonymous' %}
+    """)
+    html = template.render(Context({}))
+    soup = BeautifulSoup(html, "html.parser")
+    link_tag = soup.find("link")
+    assert link_tag["href"] == "/static/dist/assets/font.otf"
+    assert link_tag["type"] == "font/otf"
+
+
+def test_preload_assets_image():
+    template = Template("""
+    {% load django_vite %}
+    {% vite_preload_assets 'src/entry-with-assets.js' file_ext='.png' as_type='image' %}
+    """)
+    html = template.render(Context({}))
+    soup = BeautifulSoup(html, "html.parser")
+    link_tag = soup.find("link")
+    assert link_tag["href"] == "/static/dist/assets/image.png"
+    assert link_tag["rel"] == ["preload"]
+    assert link_tag["as"] == "image"
+    assert link_tag["type"] == "image/png"
+
+
+def test_entry_not_found():
+    template = Template("""
+    {% load django_vite %}
+    {% vite_preload_assets 'src/non-existent-entry.js' file_ext='.otf' as_type='font' %}
+    """)
+    html = template.render(Context({}))
+    assert html.strip() == ""
+
+
+def test_entry_without_assets():
+    template = Template("""
+    {% load django_vite %}
+    {% vite_preload_assets 'src/entry-without-assets.js' file_ext='.svg' as_type='image' %}
+    """)
+    html = template.render(Context({}))
+    assert html.strip() == ""
+
+
+def test_no_matching_assets():
+    template = Template("""
+    {% load django_vite %}
+    {% vite_preload_assets 'src/entry-with-assets.js' file_ext='.svg' as_type='image' %}
+    """)
+    html = template.render(Context({}))
+    assert html.strip() == ""
+
+
+def test_unknown_mimetype():
+    template = Template("""
+    {% load django_vite %}
+    {% vite_preload_assets 'src/entry-with-assets.js' file_ext='.unknown' as_type='object' %}
+    """)
+    html = template.render(Context({}))
+    soup = BeautifulSoup(html, "html.parser")
+    link_tag = soup.find("link")
+    assert link_tag["rel"] == ["preload"]
+    assert link_tag["href"] == "/static/dist/assets/data.unknown"
+    assert link_tag["as"] == "object"


### PR DESCRIPTION
Add new Django template tag to generate <link rel="preload"> tags for Vite-bundled assets, enabling early loading of critical resources like fonts and images to improve page load performance.

- Add `assets` field to ManifestEntry to support asset references in Vite manifest
- Implement `generate_preload_assets_tags` method in `DjangoViteAppClient`
- Add `vite_preload_assets` templatetag w/ `file_ext`, `as_type` and `**kwargs`
- Custom args like `crossorigin` for fonts supported via `**kwargs`
- Automatic MIME type detection using `mimetypes` from standard library

Usage: {% vite_preload_assets 'src/entry.js' file_ext='.woff2' as_type='font' %}

---

This template tag addresses the performance issue where fonts loaded via CSS `@font-face` rules don't start downloading until after the CSS is parsed, causing layout shifts when fonts swap in. For example:

You can put this in the `<head>` of a base template

```
{% vite_preload_assets 'theme/fonts.css.ts' file_ext=".woff2" as_type="font" crossorigin="anonymous" %}
```

Where `theme/fonts.css.ts` is like:

```ts
import { globalFontFace } from '@vanilla-extract/css';

const fontDefinitions = [
  {
    familyName: 'MyFont`',
    pathName: 'myfont',
    weights: [200, 300, 400, 500, 600, 700, 800],
    styles: ['normal', 'italic'],
  },
  // ... other essential fonts
];

function generateFontFaces(font: (typeof fontDefinitions)[number]) {
  for (const weight of font.weights) {
    for (const style of font.styles) {
      const fontFile = `${font.pathName}-latin-${weight}-${style}.woff2`;
      // you'd have to `npm install @fontsource/myfont` for this to work
      const path = `@fontsource/${font.pathName}/files/${fontFile}`;

      globalFontFace(font.familyName, {
        fontStyle: style,
        fontWeight: weight,
        // sets `font-display: block` to avoid CLS
        fontDisplay: 'block',
        src: `url('${path}') format('woff2')`,
      });
    }
  }
}

fontDefinitions.forEach(generateFontFaces);
```

Also, the template tag name might cause confusion with the existing `vite_preload_asset` (no "s") tag, so maybe I should rename it to `vite_preload_links` or something..?

Anyways, I hope that extra context helps explain why I'm making this contribution. I've tried my best to follow the repo's existing patterns and included unit tests to maintain the project's high test coverage.

Please let me know if you have any questions or would like me to make any changes.