### PR TITLE
docs: updates kwargs example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ like the previous tag.**
 If you're using React, this will generate the Javascript `<script/>` needed to support React HMR.
 
 ```
-{% vite_react_refresh nonce="{{ request.csp_nonce }}" %}
+{% vite_react_refresh nonce=request.csp_nonce %}
 ```
 
 Any kwargs passed to vite_react_refresh will be added to its generated `<script/>` tag. For example, if your site is configured with a Content Security Policy using [django-csp](https://github.com/mozilla/django-csp) you'll want to add this value for `nonce`.


### PR DESCRIPTION
Minor documentation update. 

Don't use `{{ ... }}` inside a template tag, use template variables.